### PR TITLE
JE-29027 [Layershift] Disabling VCS autoupdate setting Alias

### DIFF
--- a/usr/lib/jelastic/libs/apache-php-deploy.lib
+++ b/usr/lib/jelastic/libs/apache-php-deploy.lib
@@ -18,6 +18,7 @@
 APACHEPHPDEPLOYLIB_VERSION="0.1";
 
 HTTPD_ALIASES_FILE="/etc/httpd/conf.d/aliases.conf";
+DEFAULT_CONTEXT="ROOT";
 include os;
 $PROGRAM 'sed';
 
@@ -26,7 +27,9 @@ function setContext(){
     
    # Alias /error/ "/var/www/error/"
    $SED -i "/Alias\s\{1,\}\/${context}\s\{1,\}.*/d" $HTTPD_ALIASES_FILE;
-   echo "Alias /${context} \"${WEBROOT}/${context}\"" >> $HTTPD_ALIASES_FILE;
+   if [[ "$context" != "$DEFAULT_CONTEXT" ]]; then
+     echo "Alias /${context} \"${WEBROOT}/${context}\"" >> $HTTPD_ALIASES_FILE;
+   fi
    reloadService ${SERVICE} > /dev/null 2>&1;
 }
 
@@ -45,6 +48,8 @@ function rename(){
     local newContext=$1;
     local oldContext=$2;
     WEBROOT1=$( $SED "s/\//\\\\\\//g" <<< ${WEBROOT} );
-    $SED -i "s/^Alias\s\{0,\}\/${oldContext}\s\{0,\}\"${WEBROOT1}\/${oldContext}\"/Alias \/${newContext} \"${WEBROOT1}\/${newContext}\"/" $HTTPD_ALIASES_FILE;
+    if [[ "$oldContext" != "$DEFAULT_CONTEXT" ]]; then
+      $SED -i "s/^Alias\s\{0,\}\/${oldContext}\s\{0,\}\"${WEBROOT1}\/${oldContext}\"/Alias \/${newContext} \"${WEBROOT1}\/${newContext}\"/" $HTTPD_ALIASES_FILE;
+    fi
     reloadService ${SERVICE} > /dev/null 2>&1;
 }

--- a/usr/lib/jelastic/libs/apache-php-deploy.lib
+++ b/usr/lib/jelastic/libs/apache-php-deploy.lib
@@ -39,7 +39,9 @@ function delContext(){
    # Alias /error/ "/var/www/error/"
    
    WEBROOT1=$( $SED "s/\//\\\\\\//g" <<< ${WEBROOT} );
-   $SED -i "/^Alias\s\{0,\}\/${context}\s\{0,\}\"${WEBROOT1}\/${context}\"/d"  $HTTPD_ALIASES_FILE;
+   if [[ "$context" != "$DEFAULT_CONTEXT" ]]; then
+     $SED -i "/^Alias\s\{0,\}\/${context}\s\{0,\}\"${WEBROOT1}\/${context}\"/d"  $HTTPD_ALIASES_FILE;
+   fi
    reloadService ${SERVICE} > /dev/null 2>&1;
 }
 

--- a/usr/lib/jelastic/libs/nginx-php-deploy.lib
+++ b/usr/lib/jelastic/libs/nginx-php-deploy.lib
@@ -18,15 +18,17 @@
 
 [ -n "${NGINXPHPDEPLOYLIB_VERSION:-}" ] && return 0;
 NGINXPHPDEPLOYLIB_VERSION="0.1";
-
+DEFAULT_CONTEXT="ROOT";
 NGINX_ALIASES_FILE="/etc/nginx/aliases.conf";
 include os;
 
 function setContext(){
   local context=$1;
   WEBROOT1=$( $SED "s/\//\\\\\\//g" <<< ${WEBROOT} );
-  $SED -i "/^location\s\{0,\}\/${context}\s\{0,\}{\s\{0,\}alias\s\{0,\}${WEBROOT1}\/${context};\s\{0,\}}/d"  $NGINX_ALIASES_FILE;
-  echo "location /${context} { alias ${WEBROOT}/${context}; }" >> $NGINX_ALIASES_FILE;
+  if [[ "$context" != "$DEFAULT_CONTEXT" ]]; then
+    $SED -i "/^location\s\{0,\}\/${context}\s\{0,\}{\s\{0,\}alias\s\{0,\}${WEBROOT1}\/${context};\s\{0,\}}/d"  $NGINX_ALIASES_FILE;
+    echo "location /${context} { alias ${WEBROOT}/${context}; }" >> $NGINX_ALIASES_FILE;
+  fi
   reloadServiceSilent nginx || { stopServiceSilent nginx; startServiceSilent nginx; }
 }
 
@@ -36,8 +38,9 @@ function delContext(){
    # Alias /error/ "/var/www/error/"
 
    WEBROOT1=$( $SED "s/\//\\\\\\//g" <<< ${WEBROOT} );
-   $SED -i "/^location\s\{0,\}\/${context}\s\{0,\}{\s\{0,\}alias\s\{0,\}${WEBROOT1}\/${context};\s\{0,\}}/d"  $NGINX_ALIASES_FILE;
-
+   if [[ "$context" != "$DEFAULT_CONTEXT" ]]; then
+     $SED -i "/^location\s\{0,\}\/${context}\s\{0,\}{\s\{0,\}alias\s\{0,\}${WEBROOT1}\/${context};\s\{0,\}}/d"  $NGINX_ALIASES_FILE;
+   fi
    reloadServiceSilent nginx || { stopServiceSilent nginx; startServiceSilent nginx; }
 }
 
@@ -46,6 +49,8 @@ function rename(){
     local newContext=$1;
     local oldContext=$2;
     WEBROOT1=$( $SED "s/\//\\\\\\//g" <<< ${WEBROOT} );
-    $SED -i "s/^location\s\{0,\}\/${oldContext}\s\{0,\}{\s\{0,\}alias\s\{0,\}${WEBROOT1}\/${oldContext};\s\{0,\}}/location \/${newContext} { alias ${WEBROOT1}\/${newContext}; }/"  $NGINX_ALIASES_FILE;
+    if [[ "$oldContext" != "$DEFAULT_CONTEXT" ]]; then
+      $SED -i "s/^location\s\{0,\}\/${oldContext}\s\{0,\}{\s\{0,\}alias\s\{0,\}${WEBROOT1}\/${oldContext};\s\{0,\}}/location \/${newContext} { alias ${WEBROOT1}\/${newContext}; }/"  $NGINX_ALIASES_FILE;
+    fi
     reloadServiceSilent nginx || { stopServiceSilent nginx; startServiceSilent nginx; }
 }


### PR DESCRIPTION
This is not needed for ROOT context. may break user's setup, especially if they change document root to directory within ROOT.

I've added a switch not to add alias for ROOT, only for other directories, for Apache and Nginx actually.